### PR TITLE
Adding certificate generation feature

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,12 +4,22 @@ etcd_group: etcd
 etcd_install_dir: /usr/local/bin
 etcd_data_dir: /var/lib/etcd
 
+etcd_group_name: etcd
 etcd_master_group_name: etcd-master
 
 etcd_secure: True
 etcd_pki_dir: ~/pki-dir
+etcd_pki_csr_conf_suffix: -csr.conf
+etcd_pki_csr_suffix: .csr
 etcd_pki_key_suffix: -key.pem
 etcd_pki_cert_suffix: .pem
+etcd_pki_key_size: 2048
+etcd_pki_cert_duration: 36500
+
+etcd_gen_pki_country: ''
+etcd_gen_pki_state: ''
+etcd_gen_pki_locality: ''
+etcd_gen_pki_organization: ''
 
 etcd_use_ips: True
 etcd_network_iface: default

--- a/tasks/gen-pki.yml
+++ b/tasks/gen-pki.yml
@@ -1,0 +1,132 @@
+---
+- name: gen-pki | Check ca key
+  stat:
+    path: '{{ etcd_pki_ca_key_dest }}'
+  delegate_to: '{{ groups[etcd_group_name][0] }}'
+  register: gen_pki_ca_key
+
+- name: gen-pki | Check host keys
+  stat:
+    path: '{{ etcd_pki_key_dest }}'
+  delegate_to: '{{ groups[etcd_group_name][0] }}'
+  register: gen_pki_key
+
+- name: gen-pki | Generate missing CA
+  become: yes
+  become_user: root
+  block:
+  - name: gen-pki | Generate ca key
+    command: 'openssl genrsa -out {{ etcd_pki_ca_key_dest }} {{ etcd_pki_key_size }}'
+
+  - name: gen-pki | Generate ca cert
+    command: >-
+      openssl req -x509 -new -nodes
+        -subj '/CN={{ etcd_cluster_name }}-ca'
+        -days '{{ etcd_pki_cert_duration }}'
+        -key '{{ etcd_pki_ca_key_dest }}'
+        -out '{{ etcd_pki_ca_cert_dest }}'
+  when:
+  - not gen_pki_ca_key.stat.exists
+  - inventory_hostname == groups[etcd_group_name][0]
+
+- name: gen-pki | Create host keys
+  become: yes
+  become_user: root
+  command: 'openssl genrsa -out {{ etcd_pki_key_dest }} {{ etcd_pki_key_size }}'
+  delegate_to: '{{ groups[etcd_group_name][0] }}'
+  when: not gen_pki_key.stat.exists
+
+- name: gen-pki | Render openssl csr config
+  become: yes
+  become_user: root
+  template:
+    src: 'csr.conf.j2'
+    dest: '{{ etcd_pki_csr_conf_dest }}'
+  delegate_to: '{{ groups[etcd_group_name][0] }}'
+  register: gen_pki_csr_config
+
+- name: gen-pki | Create host signing requests
+  become: yes
+  become_user: root
+  command: >-
+    openssl req -new
+      -config '{{ etcd_pki_csr_conf_dest }}'
+      -key '{{ etcd_pki_key_dest }}'
+      -out '{{ etcd_pki_csr_dest }}'
+  delegate_to: '{{ groups[etcd_group_name][0] }}'
+  when: not gen_pki_key.stat.exists or gen_pki_csr_config.changed
+  register: gen_pki_new_csr
+
+- name: gen-pki | Sign host certs
+  become: yes
+  become_user: root
+  command: >-
+    openssl x509 -req -CAcreateserial
+      -days '{{ etcd_pki_cert_duration }}'
+      -extensions v3_ext -extfile '{{ etcd_pki_csr_conf_dest }}'
+      -CA '{{ etcd_pki_ca_cert_dest }}' -CAkey '{{ etcd_pki_ca_key_dest }}'
+      -in '{{ etcd_pki_csr_dest }}' -out '{{ etcd_pki_cert_dest }}'
+  delegate_to: '{{ groups[etcd_group_name][0] }}'
+  when: not gen_pki_ca_key.stat.exists or gen_pki_new_csr.changed
+
+- name: gen-pki | List keys
+  find:
+    paths:
+    - '{{ etcd_cluster_pki_dir }}'
+    patterns:
+    - '*{{ etcd_pki_key_suffix }}'
+  register: gen_pki_key_files
+
+- name: gen-pki | List certs
+  find:
+    paths:
+    - '{{ etcd_cluster_pki_dir }}'
+    patterns:
+    - '*{{ etcd_pki_cert_suffix }}'
+    - '*{{ etcd_pki_csr_suffix }}'
+    - '*{{ etcd_pki_csr_conf_suffix }}'
+    excludes:
+    - '*{{ etcd_pki_key_suffix }}'
+  register: gen_pki_cert_files
+
+- name: gen-pki | Handle pki file permissions
+  become: yes
+  become_user: root
+  block:
+  - name: gen-pki | Set owner
+    file:
+      path: '{{ etcd_cluster_pki_dir }}'
+      state: directory
+      owner: '{{ etcd_user }}'
+      group: '{{ etcd_group }}'
+      recurse: true
+
+  - name: gen-pki | Set key permissions
+    file:
+      path: '{{ item.path }}'
+      mode: '0400'
+    with_items: '{{ gen_pki_key_files.files }}'
+
+  - name: gen-pki | Set cert permissions
+    file:
+      path: '{{ item.path }}'
+      mode: '0600'
+    with_items: '{{ gen_pki_cert_files.files }}'
+
+- name: gen-pki | Create tls bundle
+  become: yes
+  become_user: root
+  shell: tar cz -C '{{ etcd_cluster_pki_dir }}' . | base64 --wrap=0
+  args:
+    warn: false
+  run_once: true
+  delegate_to: '{{ groups[etcd_group_name][0] }}'
+  register: etcd_cert_bundle
+
+- name: gen-pki | Distribute tls bundle
+  become: yes
+  become_user: root
+  shell: base64 -d | tar xz -C '{{ etcd_cluster_pki_dir }}'
+  args:
+    stdin: '{{ etcd_cert_bundle.stdout }}'
+  when: not inventory_hostname == groups[etcd_group_name][0]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,8 +28,22 @@
     - /etc/etcd
     - '{{ etcd_cluster_pki_dir }}'
 
+- name: check for local pki directory
+  local_action:
+    module: stat
+    path: '{{ etcd_pki_dir }}'
+  run_once: true
+  register: local_pki_dir
+
 - include_tasks: pki.yml
-  when: etcd_secure
+  when:
+  - etcd_secure
+  - local_pki_dir.stat.exists
+
+- include_tasks: gen-pki.yml
+  when:
+  - etcd_secure
+  - not local_pki_dir.stat.exists
 
 - name: install etcd.service configuration
   become: yes

--- a/templates/csr.conf.j2
+++ b/templates/csr.conf.j2
@@ -1,0 +1,36 @@
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+
+[ dn ]
+CN = {{ ansible_fqdn }}
+{% if etcd_gen_pki_organization|length %}
+O = {{ etcd_gen_pki_organization }}
+{% endif %}
+{% if etcd_gen_pki_locality|length %}
+L = {{ etcd_gen_pki_locality }}
+{% endif %}
+{% if etcd_gen_pki_state|length %}
+ST = {{ etcd_gen_pki_state }}
+{% endif %}
+{% if etcd_gen_pki_country|length %}
+C = {{ etcd_gen_pki_country }}
+{% endif %}
+
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+DNS.1 = {{ ansible_fqdn }}
+DNS.2 = {{ ansible_hostname }}
+IP.1 = {{ ansible_default_ipv4.address }}
+
+[ v3_ext ]
+authorityKeyIdentifier=keyid,issuer:always
+basicConstraints=CA:FALSE
+keyUsage=keyEncipherment,dataEncipherment
+extendedKeyUsage=serverAuth,clientAuth
+subjectAltName=@alt_names

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,12 @@ etcd_cluster: "{% for host in groups[etcd_master_group_name] %}{{ hostvars[host]
 etcd_cluster_data_dir: '{{ etcd_data_dir }}/{{ etcd_cluster_name }}.etcd'
 etcd_cluster_pki_dir: '{{ etcd_data_dir }}/{{ etcd_cluster_name }}.pki'
 
+etcd_pki_csr_conf_file: '{{ inventory_hostname }}{{ etcd_pki_csr_conf_suffix }}'
+etcd_pki_csr_conf_dest: '{{ etcd_cluster_pki_dir }}/{{ etcd_pki_csr_conf_file }}'
+
+etcd_pki_csr_file: '{{ inventory_hostname }}{{ etcd_pki_csr_suffix }}'
+etcd_pki_csr_dest: '{{ etcd_cluster_pki_dir }}/{{ etcd_pki_csr_file }}'
+
 etcd_pki_key_file: '{{ inventory_hostname }}{{ etcd_pki_key_suffix }}'
 etcd_pki_key_src: '{{ etcd_pki_dir }}/{{ etcd_pki_key_file }}'
 etcd_pki_key_dest: '{{ etcd_cluster_pki_dir }}/{{ etcd_pki_key_file }}'
@@ -16,5 +22,7 @@ etcd_pki_cert_src: '{{ etcd_pki_dir }}/{{ etcd_pki_cert_file }}'
 etcd_pki_cert_dest: '{{ etcd_cluster_pki_dir }}/{{ etcd_pki_cert_file }}'
 
 etcd_pki_ca_file: 'ca{{ etcd_pki_cert_suffix }}'
+etcd_pki_ca_key_file: 'ca{{ etcd_pki_key_suffix }}'
 etcd_pki_ca_cert_src: '{{ etcd_pki_dir }}/{{ etcd_pki_ca_file }}'
 etcd_pki_ca_cert_dest: '{{ etcd_cluster_pki_dir }}/{{ etcd_pki_ca_file }}'
+etcd_pki_ca_key_dest: '{{ etcd_cluster_pki_dir }}/{{ etcd_pki_ca_key_file }}'


### PR DESCRIPTION
This PR attempts to add the ability to generate the cluster's certificates on one machine and distribute the generated certificates across all the machines in the etcd cluster.

Currently this feature is gated by a check to see if the local directory pointed to by `etcd_pki_dir` exists.