### PR TITLE
Split config for client and peer networks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,10 @@ etcd_pki_key_suffix: -key.pem
 etcd_pki_cert_suffix: .pem
 
 etcd_use_ips: True
-etcd_network_iface: default
+etcd_iface_public: '{{ etcd_network_iface | default("all") }}'
+etcd_iface_cluster: '{{ etcd_network_iface | default("default") }}'
+etcd_port_client: 2379
+etcd_port_peer: 2380
 
 etcd_cluster_name: test-cluster-name
 etcd_initial_cluster_token: d8bf8cc6-5158-11e6-8f13-3b32f4935bde

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+
+- name: Collect facts
+  set_fact:
+    cacheable: yes
+    etcd_listen_public: '{{ "0.0.0.0" if etcd_iface_public == "all" else ansible_default_ipv4.address if etcd_iface_public == "default" else hostvars[inventory_hostname]["ansible_" ~ etcd_iface_public]["ipv4"]["address"] }}'
+    etcd_listen_cluster: '{{ "0.0.0.0" if etcd_iface_cluster == "all" else ansible_default_ipv4.address if etcd_iface_cluster == "default" else hostvars[inventory_hostname]["ansible_" ~ etcd_iface_cluster]["ipv4"]["address"] }}'
+    etcd_address_public: '{{ ansible_fqdn if not etcd_use_ips | bool else ansible_default_ipv4.address if etcd_iface_public is in [ "all", "default" ] else hostvars[inventory_hostname]["ansible_" ~ etcd_iface_public]["ipv4"]["address"] }}'
+    etcd_address_cluster: '{{ ansible_fqdn if not etcd_use_ips | bool else ansible_default_ipv4.address if etcd_iface_cluster is in [ "all", "default" ] else hostvars[inventory_hostname]["ansible_" ~ etcd_iface_cluster]["ipv4"]["address"] }}'
+
 - name: create etcd group
   become: yes
   become_user: root
@@ -29,7 +38,7 @@
     - '{{ etcd_cluster_pki_dir }}'
 
 - include_tasks: pki.yml
-  when: etcd_secure
+  when: etcd_secure | bool
 
 - name: install etcd.service configuration
   become: yes

--- a/templates/etcd.conf.j2
+++ b/templates/etcd.conf.j2
@@ -1,19 +1,24 @@
 # [member]
-ETCD_NAME="{{inventory_hostname}}"
+ETCD_NAME="{{ansible_fqdn}}"
 ETCD_DATA_DIR="{{etcd_cluster_data_dir}}"
 #ETCD_SNAPSHOT_COUNTER="10000"
 #ETCD_HEARTBEAT_INTERVAL="100"
 #ETCD_ELECTION_TIMEOUT="1000"
-ETCD_LISTEN_CLIENT_URLS="{{etcd_scheme}}://localhost:2379,{{etcd_scheme}}://{{etcd_public_address}}:2379"
+{% if etcd_iface_public == 'all' %}
+{% set client_endpoints = [ etcd_listen_public ] %}
+{% else %}
+{% set client_endpoints = [ etcd_listen_public, '127.0.0.1' ] %}
+{% endif %}
+ETCD_LISTEN_CLIENT_URLS="{{ client_endpoints | map('regex_replace', '^(.+)$', etcd_scheme ~ '\\1' ~ ':' ~ etcd_port_client) | join(',') }}"
 #ETCD_MAX_SNAPSHOTS="5"
 #ETCD_MAX_WALS="5"
 #ETCD_CORS=""
 #
 # [cluster]
 {% if inventory_hostname in groups[etcd_master_group_name] %}
-ETCD_LISTEN_PEER_URLS="{{etcd_scheme}}://{{etcd_public_address}}:2380"
-ETCD_ADVERTISE_CLIENT_URLS="{{etcd_scheme}}://{{etcd_public_address}}:2379"
-ETCD_INITIAL_ADVERTISE_PEER_URLS="{{etcd_scheme}}://{{etcd_public_address}}:2380"
+ETCD_LISTEN_PEER_URLS="{{etcd_scheme}}{{etcd_listen_cluster}}:{{etcd_port_peer}}"
+ETCD_ADVERTISE_CLIENT_URLS="{{etcd_scheme}}{{etcd_address_public}}:{{etcd_port_client}}"
+ETCD_INITIAL_ADVERTISE_PEER_URLS="{{etcd_scheme}}{{etcd_address_cluster}}:{{etcd_port_peer}}"
 {% endif %}
 ETCD_INITIAL_CLUSTER="{{etcd_cluster}}"
 ETCD_INITIAL_CLUSTER_STATE="new"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,7 @@
 ---
 
-etcd_public_address: "{% if etcd_use_ips %}{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] if etcd_network_iface == 'default' else hostvars[inventory_hostname]['ansible_' + etcd_network_iface]['ipv4']['address'] }}{% else %}{{ inventory_hostname }}{% endif %}"
-etcd_scheme: "{% if etcd_secure %}https{% else %}http{% endif %}"
-etcd_cluster: "{% for host in groups[etcd_master_group_name] %}{{ hostvars[host]['inventory_hostname'] }}={{ etcd_scheme }}://{% if etcd_use_ips %}{{ hostvars[host]['ansible_default_ipv4']['address'] if etcd_network_iface == 'default' else hostvars[host]['ansible_' + etcd_network_iface]['ipv4']['address'] }}{% else %}{{ host }}{% endif %}:2380{% if not loop.last %},{% endif %}{% endfor %}"
+etcd_scheme: "{% if etcd_secure %}https{% else %}http{% endif %}://"
+etcd_cluster: "{% for host in groups[etcd_master_group_name] %}{{ hostvars[host]['ansible_fqdn'] }}={{ etcd_scheme }}{{ hostvars[host]['etcd_address_cluster'] }}:{{ etcd_port_peer }}{% if not loop.last %},{% endif %}{% endfor %}"
 
 etcd_cluster_data_dir: '{{ etcd_data_dir }}/{{ etcd_cluster_name }}.etcd'
 etcd_cluster_pki_dir: '{{ etcd_data_dir }}/{{ etcd_cluster_name }}.pki'


### PR DESCRIPTION
Add two new parameters instead of old `etcd_network_iface`:

  - etcd_iface_public to define client network interface
  - etcd_iface_cluster to define cluster network interface

and change configuration file template to define different network settings
for client (public) and peer (internal cluster) networks.