### PR TITLE
add etcd_enable_v2 parameter

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,3 +22,5 @@ etcd_initial_cluster_token: d8bf8cc6-5158-11e6-8f13-3b32f4935bde
 
 etcd_init_system: systemd
 etcd_launch: True
+
+etcd_enable_v2: True # Accept etcd V2 client requests

--- a/templates/etcd.conf.j2
+++ b/templates/etcd.conf.j2
@@ -10,6 +10,7 @@ ETCD_DATA_DIR="{{etcd_cluster_data_dir}}"
 {% set client_endpoints = [ etcd_listen_public, '127.0.0.1' ] %}
 {% endif %}
 ETCD_LISTEN_CLIENT_URLS="{{ client_endpoints | map('regex_replace', '^(.+)$', etcd_scheme ~ '\\1' ~ ':' ~ etcd_port_client) | join(',') }}"
+ETCD_ENABLE_V2={{etcd_enable_v2}}
 #ETCD_MAX_SNAPSHOTS="5"
 #ETCD_MAX_WALS="5"
 #ETCD_CORS=""


### PR DESCRIPTION
Hi !

Thanks for this role, it is very useful

Since the version 3.4, the version 2 of the API is disabled by default:

https://github.com/etcd-io/etcd/blob/master/Documentation/upgrades/upgrade_3_4.md#make-etcd---enable-v2false-default

You can activate the V2 API with `--enable-v2=true` :

https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/configuration.md#--enable-v2

I added this parameter to the ansible config variable. I set this variable to `true` by default to avoid breaking any previous playbook