### PR TITLE
Fix when statement error in etcd member handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -19,7 +19,7 @@
   become_user: root
   when:
   - etcd_launch | bool
-  - inventory_hostname is not in groups[etcd_master_group_name]
+  - inventory_hostname is not in (groups[etcd_master_group_name])
   service:
     name: etcd
     state: restarted


### PR DESCRIPTION
Closes #15  
It appears that the original was being parsed as `(inventory_hostname is not in groups)[etcd_master_group_name]`