### PR TITLE
More control over environment variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,5 @@ etcd_init_system: systemd
 etcd_launch: True
 
 etcd_enable_v2: True # Accept etcd V2 client requests
+
+etcd_additional_envvars: {}

--- a/templates/etcd.conf.j2
+++ b/templates/etcd.conf.j2
@@ -51,3 +51,8 @@ ETCD_PEER_TRUSTED_CA_FILE="{{etcd_pki_ca_cert_dest}}"
 #ETCD_DEBUG="true"
 # examples for -log-package-levels etcdserver=WARNING,security=DEBUG
 #ETCD_LOG_PACKAGE_LEVELS="etcdserver=DEBUG"
+
+# [custom_env_vars]
+{% for k, v in etcd_additional_envvars.items() %}
+{{k}}="{{v}}"
+{% endfor %}


### PR DESCRIPTION
This PR would allow any arbitrary configuration environment variables (documented at https://etcd.io/docs/current/op-guide/configuration/) to be added to `/etc/etcd/etcd.conf`, as I'd requested in #14.