### PR TITLE
Allow configuration of IO priority.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,6 @@ etcd_launch: True
 etcd_enable_v2: True # Accept etcd V2 client requests
 
 etcd_additional_envvars: {}
+
+etcd_io_class: 2 # best effort
+etcd_io_priority: 0 # highest priority

--- a/templates/etcd.service.j2
+++ b/templates/etcd.service.j2
@@ -8,7 +8,7 @@ User={{etcd_user}}
 WorkingDirectory={{etcd_data_dir}}/
 EnvironmentFile=-/etc/etcd/etcd.conf
 # set GOMAXPROCS to number of processors
-ExecStart=/bin/bash -c "GOMAXPROCS=$(nproc) {{etcd_install_dir}}/etcd"
+ExecStart=/bin/bash -c "GOMAXPROCS=$(nproc) ionice -c{{etcd_io_class}} -n{{etcd_io_priority}} {{etcd_install_dir}}/etcd"
 Restart=on-failure
 LimitNOFILE=65536
 


### PR DESCRIPTION
I've found on my CI cluster I need to tweak the IO priority of etcd or it becomes unhappy. This PR makes ionice levels configurable in the systemd unit, and uses the values from https://etcd.io/docs/v3.5/tuning/ as the default. I have tested this change in my environment and it works for me.