### PR TITLE
Adding option for setting TimeoutStartSec in the systemd unit file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,4 +25,5 @@ etcd_launch: True
 
 etcd_enable_v2: True # Accept etcd V2 client requests
 
+etcd_service_start_timeout: 5min
 etcd_additional_envvars: {}

--- a/templates/etcd.service.j2
+++ b/templates/etcd.service.j2
@@ -3,6 +3,7 @@ Description=Etcd Server
 After=network.target
 
 [Service]
+TimeoutStartSec={{etcd_service_start_timeout}}
 Type=notify
 User={{etcd_user}}
 WorkingDirectory={{etcd_data_dir}}/


### PR DESCRIPTION
We find that our cluster machines can't always restart within the default timeout because the startup can take too long leading to a "restart loop" of the service.

Restart loop:

```
Jan 06 21:42:31 members-etcd-0 etcd[986]: recovered store from snapshot at index 415335351
Jan 06 21:42:31 members-etcd-0 etcd[986]: restore compact to 209466567
Jan 06 21:43:20 members-etcd-0 etcd[986]: restarting member 833678c85fd850b6 in cluster decccb21f36aa265 at commit index 41
Jan 06 21:43:20 members-etcd-0 bash[986]: raft2022/01/06 21:43:20 INFO: 833678c85fd850b6 switched to configuration voters=(
Jan 06 21:43:20 members-etcd-0 bash[986]: raft2022/01/06 21:43:20 INFO: 833678c85fd850b6 became follower at term 385
Jan 06 21:43:20 members-etcd-0 bash[986]: raft2022/01/06 21:43:20 INFO: newRaft 833678c85fd850b6 [peers: [5a64ff1b0d93c079,
Jan 06 21:43:20 members-etcd-0 etcd[986]: enabled capabilities for version 3.4
Jan 06 21:43:20 members-etcd-0 etcd[986]: added member 5a64ff1b0d93c079 [http://10.0.7.158:2380] to cluster decccb21f36aa26
Jan 06 21:43:20 members-etcd-0 etcd[986]: added member 833678c85fd850b6 [http://10.0.6.169:2380] to cluster decccb21f36aa26
Jan 06 21:43:20 members-etcd-0 etcd[986]: added member c66fa42b03d931eb [http://10.0.8.97:2380] to cluster decccb21f36aa265
Jan 06 21:43:20 members-etcd-0 etcd[986]: set the cluster version to 3.4 from store
Jan 06 21:43:20 members-etcd-0 etcd[986]: simple token is not cryptographically signed
Jan 06 21:43:20 members-etcd-0 etcd[986]: restore compact to 209466567
Jan 06 21:43:41 members-etcd-0 systemd[1]: etcd.service: Start operation timed out. Terminating.
Jan 06 21:43:41 members-etcd-0 systemd[1]: etcd.service: Failed with result 'timeout'.
Jan 06 21:43:41 members-etcd-0 systemd[1]: Failed to start Etcd Server.
-- Subject: Unit etcd.service has failed
-- Defined-By: systemd
-- Support: http://www.ubuntu.com/support
--
-- Unit etcd.service has failed.
--
-- The result is RESULT.
```

Given just a bit more time before timeout, we are successful:

```
Jan 06 21:43:49 members-etcd-0 etcd[1645]: recovered store from snapshot at index 415335351
Jan 06 21:43:49 members-etcd-0 etcd[1645]: restore compact to 209466567
Jan 06 21:44:39 members-etcd-0 etcd[1645]: restarting member 833678c85fd850b6 in cluster decccb21f36aa265 at commit index 4
Jan 06 21:44:39 members-etcd-0 bash[1645]: raft2022/01/06 21:44:39 INFO: 833678c85fd850b6 switched to configuration voters=
Jan 06 21:44:39 members-etcd-0 bash[1645]: raft2022/01/06 21:44:39 INFO: 833678c85fd850b6 became follower at term 385
Jan 06 21:44:39 members-etcd-0 bash[1645]: raft2022/01/06 21:44:39 INFO: newRaft 833678c85fd850b6 [peers: [5a64ff1b0d93c079
Jan 06 21:44:39 members-etcd-0 etcd[1645]: enabled capabilities for version 3.4
Jan 06 21:44:39 members-etcd-0 etcd[1645]: added member c66fa42b03d931eb [http://10.0.8.97:2380] to cluster decccb21f36aa26
Jan 06 21:44:39 members-etcd-0 etcd[1645]: added member 5a64ff1b0d93c079 [http://10.0.7.158:2380] to cluster decccb21f36aa2
Jan 06 21:44:39 members-etcd-0 etcd[1645]: added member 833678c85fd850b6 [http://10.0.6.169:2380] to cluster decccb21f36aa2
Jan 06 21:44:39 members-etcd-0 etcd[1645]: set the cluster version to 3.4 from store
Jan 06 21:44:39 members-etcd-0 etcd[1645]: simple token is not cryptographically signed
Jan 06 21:44:39 members-etcd-0 etcd[1645]: restore compact to 209466567
Jan 06 21:45:30 members-etcd-0 etcd[1645]: starting peer 5a64ff1b0d93c079...
Jan 06 21:45:30 members-etcd-0 etcd[1645]: started HTTP pipelining with peer 5a64ff1b0d93c079
```