### PR TITLE
Fix for etcd_use_ips=true: ansible_fqdn is not defined

### DIFF
--- a/templates/etcd.conf.j2
+++ b/templates/etcd.conf.j2
@@ -1,5 +1,5 @@
 # [member]
-ETCD_NAME="{{ansible_fqdn}}"
+ETCD_NAME="{{ ansible_fqdn if not etcd_use_ips | bool else inventory_hostname }}"
 ETCD_DATA_DIR="{{etcd_cluster_data_dir}}"
 #ETCD_SNAPSHOT_COUNTER="10000"
 #ETCD_HEARTBEAT_INTERVAL="100"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 
 etcd_scheme: "{% if etcd_secure %}https{% else %}http{% endif %}://"
-etcd_cluster: "{% for host in groups[etcd_master_group_name] %}{{ hostvars[host]['ansible_fqdn'] }}={{ etcd_scheme }}{{ hostvars[host]['etcd_address_cluster'] }}:{{ etcd_port_peer }}{% if not loop.last %},{% endif %}{% endfor %}"
+etcd_cluster: "{% for host in groups[etcd_master_group_name] %}{{ hostvars[host]['ansible_fqdn' if not etcd_use_ips | bool else 'inventory_hostname'] }}={{ etcd_scheme }}{{ hostvars[host]['etcd_address_cluster'] }}:{{ etcd_port_peer }}{% if not loop.last %},{% endif %}{% endfor %}"
 
 etcd_cluster_data_dir: '{{ etcd_data_dir }}/{{ etcd_cluster_name }}.etcd'
 etcd_cluster_pki_dir: '{{ etcd_data_dir }}/{{ etcd_cluster_name }}.pki'


### PR DESCRIPTION
In case etcd_use_ips: true ansible_fqdn is not defined and role fails. This commit fixes that.