### PR TITLE
Fix for missing etcd_service_start_timeout

### DIFF
--- a/templates/etcd.service.j2
+++ b/templates/etcd.service.j2
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 {% if etcd_service_start_timeout -%}
-TimeoutStartSec={{ etcd_service_start_timeout  }}
+TimeoutStartSec={{ etcd_service_start_timeout | default("5m") }}
 {%- endif %}
 Type={{ etcd_systemd_service_type | default("notify") }}
 User={{ etcd_user }}


### PR DESCRIPTION
Fixes https://github.com/andrewrothstein/ansible-etcd_cluster/issues/27 This ensures that the etcd_service_start_timeout has a default in the template if it's not set in the variables.