### PR TITLE
Fixed whitespace control to prevent newline removal when if condition is false

### DIFF
--- a/templates/etcd.conf.j2
+++ b/templates/etcd.conf.j2
@@ -1,13 +1,13 @@
 # [member]
 ETCD_NAME="{{ ansible_fqdn if not etcd_use_ips | bool else inventory_hostname }}"
 ETCD_DATA_DIR={{ etcd_cluster_data_dir | quote }}
-{%- if etcd_cluster_snapshot_counter is defined %}
+{% if etcd_cluster_snapshot_counter is defined %}
 ETCD_SNAPSHOT_COUNTER={{ etcd_cluster_snapshot_counter | quote }}
 {%- endif %}
-{%- if etcd_cluster_heartbeat_interval is defined %}
+{% if etcd_cluster_heartbeat_interval is defined %}
 ETCD_HEARTBEAT_INTERVAL={{ etcd_cluster_heartbeat_interval | quote }}
 {%- endif %}
-{%- if etcd_cluster_election_timeout is defined %}
+{% if etcd_cluster_election_timeout is defined %}
 ETCD_ELECTION_TIMEOUT={{ etcd_cluster_election_timeout | quote }}
 {%- endif %}
 {% if etcd_iface_public == 'all' %}
@@ -17,19 +17,19 @@ ETCD_ELECTION_TIMEOUT={{ etcd_cluster_election_timeout | quote }}
 {% endif %}
 ETCD_LISTEN_CLIENT_URLS={{ client_endpoints | map('regex_replace', '^(.+)$', etcd_scheme ~ '\\1' ~ ':' ~ etcd_port_client) | join(',') | quote }}
 ETCD_ENABLE_V2={{ etcd_enable_v2 }}
-{%- if etcd_config_max_snapshots is defined %}
+{% if etcd_config_max_snapshots is defined %}
 ETCD_MAX_SNAPSHOTS={{ etcd_config_max_snapshots | quote }}
 {%- endif %}
-{%- if etcd_config_max_wals is defined %}
+{% if etcd_config_max_wals is defined %}
 ETCD_MAX_WALS={{ etcd_config_max_wals | quote }}
 {%- endif %}
-{%- if etcd_config_cors is defined %}
+{% if etcd_config_cors is defined %}
 ETCD_CORS={{ etcd_config_cors | quote }}
 {%- endif %}
 #
 #
 # [cluster]
-{%- if inventory_hostname in groups[etcd_master_group_name] %}
+{% if inventory_hostname in groups[etcd_master_group_name] %}
 ETCD_LISTEN_PEER_URLS="{{ etcd_scheme }}{{ etcd_listen_cluster }}:{{ etcd_port_peer }}"
 ETCD_ADVERTISE_CLIENT_URLS="{{ etcd_scheme }}{{ etcd_address_public }}:{{ etcd_port_client }}"
 ETCD_INITIAL_ADVERTISE_PEER_URLS="{{ etcd_scheme }}{{ etcd_address_cluster }}:{{ etcd_port_peer }}"
@@ -63,10 +63,10 @@ ETCD_PEER_TRUSTED_CA_FILE={{ etcd_pki_ca_cert_dest | quote }}
 {% endif %}
 #
 #[logging]
-{%- if etcd_config_debug is defined and etcd_config_debug | bool %}
+{% if etcd_config_debug is defined and etcd_config_debug | bool %}
 ETCD_DEBUG={{ etcd_config_debug | bool | quote }}
 {%- endif %}
-{%- if etcd_config_log_package_levels is defined %}
+{% if etcd_config_log_package_levels is defined %}
 ETCD_LOG_PACKAGE_LEVELS={{ etcd_config_log_package_levels | quote }}
 {%- else %}
 # examples for -log-package-levels etcdserver=WARNING,security=DEBUG
@@ -74,7 +74,7 @@ ETCD_LOG_PACKAGE_LEVELS={{ etcd_config_log_package_levels | quote }}
 {%- endif %}
 #
 # [custom_env_vars]
-{%- if etcd_additional_envvars is defined %}
+{% if etcd_additional_envvars is defined %}
 {% for k, v in etcd_additional_envvars %}
 {{ k }}={{ v | quote }}
 {% endfor %}

--- a/templates/etcd.conf.j2
+++ b/templates/etcd.conf.j2
@@ -3,13 +3,13 @@ ETCD_NAME="{{ ansible_fqdn if not etcd_use_ips | bool else inventory_hostname }}
 ETCD_DATA_DIR={{ etcd_cluster_data_dir | quote }}
 {% if etcd_cluster_snapshot_counter is defined %}
 ETCD_SNAPSHOT_COUNTER={{ etcd_cluster_snapshot_counter | quote }}
-{%- endif %}
+{% endif -%}
 {% if etcd_cluster_heartbeat_interval is defined %}
 ETCD_HEARTBEAT_INTERVAL={{ etcd_cluster_heartbeat_interval | quote }}
-{%- endif %}
+{% endif -%}
 {% if etcd_cluster_election_timeout is defined %}
 ETCD_ELECTION_TIMEOUT={{ etcd_cluster_election_timeout | quote }}
-{%- endif %}
+{% endif -%}
 {% if etcd_iface_public == 'all' %}
 {% set client_endpoints = [ etcd_listen_public ] %}
 {% else %}
@@ -19,13 +19,13 @@ ETCD_LISTEN_CLIENT_URLS={{ client_endpoints | map('regex_replace', '^(.+)$', etc
 ETCD_ENABLE_V2={{ etcd_enable_v2 }}
 {% if etcd_config_max_snapshots is defined %}
 ETCD_MAX_SNAPSHOTS={{ etcd_config_max_snapshots | quote }}
-{%- endif %}
+{% endif -%}
 {% if etcd_config_max_wals is defined %}
 ETCD_MAX_WALS={{ etcd_config_max_wals | quote }}
-{%- endif %}
+{% endif -%}
 {% if etcd_config_cors is defined %}
 ETCD_CORS={{ etcd_config_cors | quote }}
-{%- endif %}
+{% endif -%}
 #
 #
 # [cluster]
@@ -33,7 +33,7 @@ ETCD_CORS={{ etcd_config_cors | quote }}
 ETCD_LISTEN_PEER_URLS="{{ etcd_scheme }}{{ etcd_listen_cluster }}:{{ etcd_port_peer }}"
 ETCD_ADVERTISE_CLIENT_URLS="{{ etcd_scheme }}{{ etcd_address_public }}:{{ etcd_port_client }}"
 ETCD_INITIAL_ADVERTISE_PEER_URLS="{{ etcd_scheme }}{{ etcd_address_cluster }}:{{ etcd_port_peer }}"
-{%- endif %}
+{% endif -%}
 #
 ETCD_INITIAL_CLUSTER={{ etcd_cluster | quote }}
 ETCD_INITIAL_CLUSTER_STATE="new"
@@ -48,7 +48,7 @@ ETCD_INITIAL_CLUSTER_TOKEN={{ etcd_initial_cluster_token | quote }}
 #[proxy]
 {% if inventory_hostname not in groups[etcd_master_group_name] %}
 ETCD_PROXY="on"
-{% endif %}
+{% endif -%}
 #
 #[security]
 {% if etcd_secure %}
@@ -60,22 +60,22 @@ ETCD_PEER_CERT_FILE={{ etcd_pki_cert_dest | quote }}
 ETCD_PEER_KEY_FILE={{ etcd_pki_key_dest | quote }}
 ETCD_PEER_CLIENT_CERT_AUTH="true"
 ETCD_PEER_TRUSTED_CA_FILE={{ etcd_pki_ca_cert_dest | quote }}
-{% endif %}
+{% endif -%}
 #
 #[logging]
 {% if etcd_config_debug is defined and etcd_config_debug | bool %}
 ETCD_DEBUG={{ etcd_config_debug | bool | quote }}
-{%- endif %}
+{% endif -%}
 {% if etcd_config_log_package_levels is defined %}
 ETCD_LOG_PACKAGE_LEVELS={{ etcd_config_log_package_levels | quote }}
-{%- else %}
+{% else %}
 # examples for -log-package-levels etcdserver=WARNING,security=DEBUG
 #ETCD_LOG_PACKAGE_LEVELS="etcdserver=DEBUG"
-{%- endif %}
+{% endif -%}
 #
 # [custom_env_vars]
 {% if etcd_additional_envvars is defined %}
 {% for k, v in etcd_additional_envvars %}
 {{ k }}={{ v | quote }}
 {% endfor %}
-{%- endif %}
+{% endif -%}

--- a/templates/etcd.service.j2
+++ b/templates/etcd.service.j2
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 {% if etcd_service_start_timeout is defined %}
 TimeoutStartSec={{ etcd_service_start_timeout }}
-{%- endif %}
+{% endif -%}
 Type={{ etcd_systemd_service_type | default("notify") }}
 User={{ etcd_user }}
 WorkingDirectory={{ etcd_data_dir }}/

--- a/templates/etcd.service.j2
+++ b/templates/etcd.service.j2
@@ -3,7 +3,7 @@ Description=Etcd Server
 After=network.target
 
 [Service]
-{%- if etcd_service_start_timeout is defined %}
+{% if etcd_service_start_timeout is defined %}
 TimeoutStartSec={{ etcd_service_start_timeout }}
 {%- endif %}
 Type={{ etcd_systemd_service_type | default("notify") }}


### PR DESCRIPTION
Whitespace control breaks on empty jinja if conditions in etcd config and unit files, rendering cluster unbootable. For example, using role with default variables  results in `/etc/etcd/etcd.conf` having the following errors

```ini
# [member]
ETCD_NAME="127.0.0.1"
ETCD_DATA_DIR=/var/lib/etcd/test-cluster-name.etcdETCD_LISTEN_CLIENT_URLS=https://1.1.1.1:2379
ETCD_ENABLE_V2=True#
#
# [cluster]ETCD_LISTEN_PEER_URLS="https://1.1.1.1:2380"
ETCD_ADVERTISE_CLIENT_URLS="https://1.1.1.1:2379"
<output omitted>
```

This PR changes whitespace control behavior, tested on ansible [core 2.16.2]