### PR TITLE
Make certificate authentication option configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ etcd_data_dir: /var/lib/etcd
 etcd_master_group_name: etcd_master
 
 etcd_secure: true
+etcd_client_cert_auth: true
+etcd_peer_client_cert_auth: true
 etcd_pki_dir: ~/pki-dir
 etcd_pki_key_suffix: -key.pem
 etcd_pki_cert_suffix: .pem

--- a/templates/etcd.conf.j2
+++ b/templates/etcd.conf.j2
@@ -54,11 +54,11 @@ ETCD_PROXY="on"
 {% if etcd_secure %}
 ETCD_CERT_FILE="{{ etcd_pki_cert_dest }}"
 ETCD_KEY_FILE="{{ etcd_pki_key_dest }}"
-ETCD_CLIENT_CERT_AUTH="true"
+ETCD_CLIENT_CERT_AUTH="{{ etcd_client_cert_auth | string | lower }}"
 ETCD_TRUSTED_CA_FILE="{{ etcd_pki_ca_cert_dest }}"
 ETCD_PEER_CERT_FILE="{{ etcd_pki_cert_dest }}"
 ETCD_PEER_KEY_FILE="{{ etcd_pki_key_dest }}"
-ETCD_PEER_CLIENT_CERT_AUTH="true"
+ETCD_PEER_CLIENT_CERT_AUTH="{{ etcd_peer_client_cert_auth | string | lower }}"
 ETCD_PEER_TRUSTED_CA_FILE="{{ etcd_pki_ca_cert_dest }}"
 {% endif %}
 #


### PR DESCRIPTION
The certificate authentication method takes precedence over the user/password method. However, it does not work with the etcd gateway and prevents the user/password method from being used.

There is a workaround for leaving a certificate's "common name" (cn) empty, allowing credentials to take precedence. Unfortunately, some certificate management services do not permit the creation of certificates with an empty common name.